### PR TITLE
Remove roles param from body

### DIFF
--- a/lib/mattermost/endpoint/teams.rb
+++ b/lib/mattermost/endpoint/teams.rb
@@ -51,11 +51,10 @@ module Mattermost
 				get("/teams/#{team_id}/members")
 			end
 
-			def add_user_to_team(team_id, user_id, roles)
+			def add_user_to_team(team_id, user_id)
 				post("/teams/#{team_id}/members", :body => {
 					:team_id => team_id,
-					:user_id => user_id,
-					:roles => roles
+					:user_id => user_id
 				}.to_json)
 			end
 


### PR DESCRIPTION
Regarding to docs we don't need to pass `roles` param in request body

https://github.com/mattermost/mattermost-api-reference/blob/master/v4/source/teams.yaml#L1137